### PR TITLE
MOR 733: Implement OpenAPI-based client for new v3 api

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ cw.workflow(
   }
 ).run({
   httpParams: { },
-  eventUpdates: { added: [], updated: [], removed: [] },
+  eventUpdates: { added: [], modified: [], removed: [] },
   user: {
     email: "...",
     firstName: "...",

--- a/examples/auto-break-time.ts
+++ b/examples/auto-break-time.ts
@@ -1,0 +1,168 @@
+// import cw, { morgen } from "morgen-cw-sdk";
+import { Interval } from "luxon";
+import cw, { sandbox } from "../src";
+import { fetchJSON, fetchMorgen, morgen } from "../src/global";
+
+const { log } = sandbox.util;
+const { luxon } = sandbox.deps;
+
+const wf = cw.workflow(
+  {
+    name: "Automatic breaks (SDK test)",
+  },
+  async function run(trigger) {
+    if (!trigger.accounts?.calendar?.[0]?.calendarId)
+      throw new Error("No calendar configured!");
+    const { accountId, calendarId } = trigger.accounts.calendar[0];
+
+    // Break preferences for the working day every day
+    //  e.g. "10am, 3pm, 6pm"
+    //  duration: { minutes: 15 }
+    const preferredBreaks = [
+      {
+        time: "10:00",
+        title: "Coffee ☕️✨",
+        duration: { minutes: 15 },
+      },
+      {
+        time: "12:00",
+        title: "Lunch 🥪",
+        duration: { minutes: 60 },
+      },
+      {
+        time: "15:00",
+        title: "Stretch break 🧘",
+        duration: { minutes: 30 },
+      },
+    ];
+
+    const { DateTime, Interval, Duration } = luxon;
+
+    const rangeDays = 7;
+
+    // Get events for the next 7 days
+    const today = DateTime.now().setZone("Europe/Zurich").startOf("day");
+    const nextWeek = today.plus({ days: rangeDays });
+
+    const evs = await morgen().events.listEventsV3({
+      accountId,
+      calendarIds: calendarId,
+      start: today.toISO({ suppressMilliseconds: true, includeOffset: false })!,
+      end: nextWeek.toISO({
+        suppressMilliseconds: true,
+        includeOffset: false,
+      })!,
+    });
+
+    const intervals =
+      evs?.data?.events?.map((e) => {
+        const start = DateTime.fromISO(e.start!, { zone: e.timeZone });
+        const end = start.plus(Duration.fromISO(e.duration!));
+        return {
+          interval: Interval.fromDateTimes(start, end),
+          isBreak: e.description?.includes("#break"),
+        };
+      }) || [];
+
+    const newBreaks: {
+      interval: Interval;
+      title: string;
+    }[] = [];
+
+    for (let day = 0; day < rangeDays; day++) {
+      const currentDay = today.plus({ day });
+      // Ignore weekends
+      if (currentDay.weekday > 5) continue;
+      for (let brk of preferredBreaks) {
+        const [hour, minute] = brk.time.split(":").map((i) => parseInt(i, 10));
+        log(brk.time, brk.time.split(":"));
+        log(hour + "h" + minute + "m");
+        const duration = Duration.fromObject(brk.duration);
+
+        // Check if the break already exists
+        let newInterval = Interval.after(
+          currentDay.set({ hour, minute }),
+          duration
+        );
+
+        let existingInterval = intervals.find((existingInterval) =>
+          existingInterval.interval.intersection(newInterval)
+        );
+        let shouldCreateBreak = true;
+        // Until there is no intersection with an existing interval, move the
+        // newly proposed break time
+        while (existingInterval) {
+          // There's an intersection, give up if it is equal to the break
+          if (
+            existingInterval.interval.equals(newInterval) &&
+            existingInterval.isBreak
+          ) {
+            existingInterval = undefined;
+            shouldCreateBreak = false;
+            // Do not add the break, there's already one there
+            continue;
+          }
+          // There's an intersection, but it's not a break,
+          // so move the start time to the end of this event.
+          newInterval = newInterval.set({
+            start: existingInterval.interval.end!,
+            end: existingInterval.interval.end?.plus(newInterval.toDuration()),
+          });
+          // Check whether this new interval intersects with an existing one
+          existingInterval = intervals.find(
+            (existingInterval) =>
+              newInterval && existingInterval.interval.intersection(newInterval)
+          );
+        }
+        if (!shouldCreateBreak) continue;
+        newBreaks.push({
+          ...brk,
+          title: brk.title || "Break",
+          interval: newInterval,
+        });
+      }
+    }
+
+    log(JSON.stringify(newBreaks));
+    log(accountId + " " + calendarId);
+
+    for (let brk of newBreaks) {
+      const start = brk.interval.start!.toISO({
+        suppressMilliseconds: true,
+        includeOffset: false,
+      })!;
+      log("Creating ... " + JSON.stringify({ start, title: brk.title }));
+      const resp = await morgen().events.createEventV3({
+        requestBody: {
+          calendarId,
+          accountId,
+          title: brk.title,
+          description: "#break",
+          timeZone: "Europe/Zurich",
+          showWithoutTime: false,
+          start,
+          duration: brk.interval.toDuration().rescale().toISO()!,
+        },
+      });
+      log("Resp " + JSON.stringify(resp));
+    }
+  }
+);
+wf.upload().then(() => wf.trigger());
+
+/*
+wf.run({
+  httpParams: {},
+  eventUpdates: { added: [], removed: [], modified: [] },
+  accounts: {
+    calendar: [
+      {
+        accountId: "123",
+        calendarId: "123",
+      },
+    ],
+  },
+  user: { email: "", firstName: "" },
+});
+//);
+//*/

--- a/examples/create-event.ts
+++ b/examples/create-event.ts
@@ -1,0 +1,87 @@
+// import cw, { morgen } from "morgen-cw-sdk";
+import cw, { sandbox } from "../src";
+
+const { morgen } = sandbox.util;
+const { luxon } = sandbox.deps;
+
+/**
+ * This is a basic example of a workflow that creates a new event in the
+ * provided calendar.
+ *
+ * NOTE: Please specify the calendar in the UI once the workflow has been
+ * uploaded.
+ */
+const wf = cw.workflow(
+  {
+    name: "SDK Example: Create an Event",
+  },
+  async function run(trigger) {
+    if (!trigger.accounts?.calendar?.[0]?.calendarId)
+      throw new Error("No calendar configured!");
+    const { accountId, calendarId } = trigger.accounts.calendar[0];
+
+    // Get exported classes of the luxon library
+    const { DateTime, Duration } = luxon;
+
+    // Create the start time using the luxon library
+    const startDT = DateTime.now().startOf("minute");
+    const start = startDT.toISO({
+      // Milliseconds aren't supported by the Morgen API
+      suppressMilliseconds: true,
+      // Exclude the time zone, which is provided separately
+      includeOffset: false,
+    })!;
+    const timeZone = startDT.zoneName || "UTC";
+
+    // Create the duration
+    const duration = Duration.fromObject({ minutes: 30 }).toISO()!;
+
+    // Set this property to:
+    //   - true to show it as an all-day event
+    //   - false to show it at a specific time of day.
+    const showWithoutTime = false;
+
+    // Perform the request using our client
+    const resp = await morgen().events.createEventV3({
+      requestBody: {
+        calendarId,
+        accountId,
+        title: "Get started with TimeTo! 🥳",
+        description:
+          "Congratulations, you just added an event to your calendar through the power of Morgen! 👏",
+        timeZone,
+        showWithoutTime,
+        start,
+        duration,
+      },
+    });
+    return resp;
+  }
+);
+
+// Upload the workflow, and trigger it when upload is complete
+wf.upload().then(() => wf.trigger());
+
+/*
+wf.run({
+  httpParams: {},
+  eventUpdates: {
+    added: [],
+    modified: [],
+    removed: [],
+  },
+  user: {
+    email: "",
+    firstName: "",
+  },
+  accounts: {
+    calendar: [
+      {
+        accountId: "6441683859cf95c5a82dd83a",
+        calendarId:
+          "WyI2NDQxNjgzODU5Y2Y5NWM1YTgyZGQ4M2EiLCJkODQzNjAzOTljZDdlMTkyNmJjOWEyZTljYjliNWUzYzViMmViMDI5ZTMzZWI1M2FlNTQ3ODg1MDg5YTNhM2ZjQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20iXQ",
+      },
+    ],
+  },
+});
+*/

--- a/examples/openai-tomorrow-summary.ts
+++ b/examples/openai-tomorrow-summary.ts
@@ -1,8 +1,8 @@
 // import cw, { morgen } from "morgen-cw-sdk";
-import cw, { morgen } from "..";
+import cw, { sandbox } from "..";
 
-const { fetchMorgen, log, fetch } = morgen.util;
-const { luxon } = morgen.deps;
+const { fetchMorgen, log, fetch } = sandbox.util;
+const { luxon } = sandbox.deps;
 
 const wf = cw.workflow(
   {
@@ -31,11 +31,12 @@ const wf = cw.workflow(
           temperature: 0.7,
         }),
       });
-      resp = JSON.parse(resp);
-      if (resp.error) {
-        throw new Error("Error with OpenAI: " + JSON.stringify(resp.error));
+      const parsed = JSON.parse(resp);
+      const error = parsed?.error;
+      if (error) {
+        throw new Error("Error with OpenAI: " + JSON.stringify(error));
       }
-      return resp.choices[0].message.content;
+      return parsed.choices[0].message.content;
     }
     if (!trigger.accounts?.calendar?.[0]?.calendarId)
       throw new Error("No calendar configured!");
@@ -59,7 +60,7 @@ const wf = cw.workflow(
         method: "GET",
       }
     );
-    const evs = JSON.parse(mresp);
+    const evs = mresp.body;
 
     // Get all busy events and format for ChatGPT
     const list: any[] = [];

--- a/examples/schedule-task.ts
+++ b/examples/schedule-task.ts
@@ -1,0 +1,65 @@
+// import cw, { morgen } from "morgen-cw-sdk";
+import cw, { sandbox } from "../src";
+
+const { morgen } = sandbox.util;
+const { luxon } = sandbox.deps;
+
+/**
+ * This example will create Morgen task and schedule for the current time.
+ *
+ * NOTE: Please specify the calendar in the UI once the workflow has been
+ * uploaded.
+ */
+const wf = cw.workflow(
+  {
+    name: "SDK Example: Schedule a Task",
+  },
+  async function run(trigger) {
+    if (!trigger.accounts?.calendar?.[0]?.calendarId)
+      throw new Error("No calendar configured!");
+    const { accountId, calendarId } = trigger.accounts.calendar[0];
+
+    // Get exported classes of the luxon library
+    const { DateTime, Duration } = luxon;
+
+    // Create the start time using the luxon library
+    const startDT = DateTime.now().startOf("minute");
+
+    const title = "Auto-scheduled task 001";
+    const estimatedDuration = Duration.fromObject({ minutes: 30 }).toISO()!;
+
+    const taskResp = await morgen().tasks.createTaskV2({
+      requestBody: {
+        title,
+        estimatedDuration,
+      },
+    });
+
+    // Perform the request using our client
+    const resp = await morgen().events.createEventV3({
+      requestBody: {
+        "morgen.so:metadata": {
+          taskId: taskResp.id.split("@")[0],
+        },
+        calendarId,
+        accountId,
+        title,
+        description:
+          "A task that I need to have automatically scheduled right now.",
+        timeZone: startDT.zoneName || "UTC",
+        showWithoutTime: false,
+        start: startDT.toISO({
+          // Milliseconds aren't supported by the Morgen API
+          suppressMilliseconds: true,
+          // Exclude the time zone, which is provided separately
+          includeOffset: false,
+        })!,
+        duration: estimatedDuration,
+      },
+    });
+    return resp;
+  }
+);
+
+// Upload the workflow, and trigger it when upload is complete
+wf.upload().then(() => wf.trigger());

--- a/examples/tracking.ts
+++ b/examples/tracking.ts
@@ -113,7 +113,7 @@ wf.upload().then(async () => {
     },
     eventUpdates: {
       added: [],
-      updated: [],
+      modified: [],
       removed: [],
     },
     user: {

--- a/generate-openapi-client.sh
+++ b/generate-openapi-client.sh
@@ -1,0 +1,8 @@
+# Generate morgen client for OpenAPI spec of `morgen-backend`
+npx openapi-typescript-codegen \
+  --input ./openapi.v3.yaml \
+  --output ./src/generated \
+  --name Morgen \
+  --client fetch \
+  --useOptions \
+  --request ./src/request.ts

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
+  maxWorkers: 1,
   preset: 'ts-jest',
   testEnvironment: 'node',
 };

--- a/openapi.v3.yaml
+++ b/openapi.v3.yaml
@@ -7,8 +7,6 @@ info:
 servers:
   - url: https://api.morgen.so
     description: Production endpoint
-  - url: https://20230926t115812-dot-morgen-d34db.oa.r.appspot.com
-    description: Developing endpoint
 
 tags:
   - name: User

--- a/openapi.v3.yaml
+++ b/openapi.v3.yaml
@@ -1,0 +1,921 @@
+openapi: 3.0.0
+info:
+  title: Morgen API
+  description: Morgen REST Api definitions
+  version: 3.0.0
+
+servers:
+  - url: https://api.morgen.so
+    description: Production endpoint
+  - url: https://20230926t115812-dot-morgen-d34db.oa.r.appspot.com
+    description: Developing endpoint
+
+tags:
+  - name: User
+    description: Operations on the current user
+  - name: Accounts
+    description: Operations on the authenticated accounts
+  - name: Tasks
+    description: Operations on Morgen Tasks
+  - name: Task Lists
+    description: Operations on Morgen Task Lists
+  - name: Calendars
+    description: Operations on calendars
+  - name: Events
+    description: Operations on calendar events
+
+paths:
+  "/identity":
+    get:
+      operationId: getUserIdentityV1
+      summary: Get user profile
+      tags:
+        - User
+      security:
+        - userToken: []
+        - apiKey: []
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/UserPropertiesImmutable"
+                  - $ref: "#/components/schemas/UserProperties"
+
+  "/identity/update":
+    post:
+      operationId: updateUserProfileV1
+      summary: Update user profile
+      tags:
+        - User
+      security:
+        - userToken: []
+        - apiKey: []
+      requestBody:
+        description: User fields to be updated
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UserProperties"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/UserPropertiesImmutable"
+                  - $ref: "#/components/schemas/UserProperties"
+
+  # NOTE: This API makes more sense with account connection routes
+  "/v3/integrations/list":
+    get:
+      operationId: listIntegrationsV3
+      summary: Get a list of supported services
+      tags:
+        - Accounts
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      groups:
+                        $ref: "#/components/schemas/IntegrationGroups"
+                      integrations:
+                        $ref: "#/components/schemas/Integrations"
+
+  "/v3/integrations/accounts/list":
+    get:
+      operationId: listAccountsV3
+      summary: Retrieve accounts list
+      description: Retrieve a list of accounts the user has access to
+      tags:
+        - Accounts
+      security:
+        - userToken: []
+        - apiKey: []
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      accounts:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/AccountProperties"
+
+  "/v3/calendars/list":
+    get:
+      operationId: listCalendarsV3
+      summary: Retrieve a list of calendars the user has access to
+      description: List all the calendars connected to Morgen.
+      tags:
+        - Calendars
+      security:
+        - userToken: []
+        - apiKey: []
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      accounts:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/AccountProperties"
+                      calendars:
+                        type: array
+                        items:
+                          allOf:
+                            - $ref: "#/components/schemas/CalendarProperties"
+                            - $ref: "#/components/schemas/CalendarContextId"
+                            - $ref: "#/components/schemas/DocumentId"
+
+  "/v3/calendars/update":
+    post:
+      operationId: updateCalendarMetadataV3
+      summary: Update calendar metadata
+      tags:
+        - Calendars
+      security:
+        - userToken: []
+        - apiKey: []
+      requestBody:
+        description: An event object
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: string
+                  description: The ID of the calendar to update
+                accountId:
+                  type: string
+                  description: The account ID of the calendar to update
+                'morgen.so:metadata':
+                  type: object
+                  properties:
+                    busy:
+                      type: boolean
+      responses:
+        "204":
+          description: Update successful
+
+  "/v3/events/list":
+    get:
+      operationId: listEventsV3
+      summary: Retrieve events from all calendars
+      description: >
+        Retrieve events from all connected calendars, occurring within a given a [`start`, `end`] time window.
+      tags:
+        - Events
+      security:
+        - userToken: []
+        - apiKey: []
+      parameters:
+        - in: query
+          name: start
+          required: true
+          schema:
+            type: string
+            format: datetime
+        - in: query
+          name: end
+          required: true
+          schema:
+            type: string
+            format: datetime
+        - in: query
+          name: accountId
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: calendarIds
+          description: >
+            If a `calendarIds` is specific, only events in the corresponding calendar are returned.
+            To filter for multiple calendars, use calendar ids separated by a comma, i.e. "calendarId_1,calendarId_2".
+          schema:
+            type: string
+
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      events:
+                        type: array
+                        items:
+                          allOf:
+                            - $ref: "#/components/schemas/EventProperties"
+                            - $ref: "#/components/schemas/EventContextId"
+                            - $ref: "#/components/schemas/DocumentId"
+
+  "/v3/events/create":
+    post:
+      operationId: createEventV3
+      summary: Create a calendar event
+      tags:
+        - Events
+      security:
+        - userToken: []
+        - apiKey: []
+      requestBody:
+        description: An event object
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: "#/components/schemas/EventContextId"
+                - $ref: "#/components/schemas/EventProperties"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - "$ref": "#/components/schemas/EventContextId"
+                  - "$ref": "#/components/schemas/EventPropertiesImmutable"
+                  - "$ref": "#/components/schemas/EventProperties"
+                  - "$ref": "#/components/schemas/DocumentId"
+                  - type: object
+                    properties:
+                      "morgen.so:requestVirtualRoom":
+                        type: string
+                        description: "If specified, a virtual video conferencing room will be added to the event. Only supported for O365/Google events."
+                        enum:
+                          - default
+
+  "/v3/events/update":
+    post:
+      operationId: updateEventV3
+      summary: Update a calendar event
+      tags:
+        - Events
+      security:
+        - userToken: []
+        - apiKey: []
+      # TODO: Add seriesUpdateMode parameter (currently only single supported anyway)
+      requestBody:
+        description: An event object
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+                - "$ref": "#/components/schemas/DocumentId"
+                - "$ref": "#/components/schemas/EventContextId"
+                - "$ref": "#/components/schemas/EventProperties"
+
+
+      responses:
+        "204":
+          description: OK
+
+  "/v3/events/delete":
+    post:
+      operationId: deleteEventV3
+      summary: Delete a calendar event
+      tags:
+        - Events
+      security:
+        - userToken: []
+        - apiKey: []
+      requestBody:
+        description: The identifier of the event to delete
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+                - "$ref": "#/components/schemas/EventContextId"
+                - "$ref": "#/components/schemas/DocumentId"
+      responses:
+        "204":
+          description: OK
+
+  "/v2/tasks/list":
+    get:
+      operationId: listTasksV2
+      summary: Retrieve tasks
+      tags:
+        - Tasks
+      security:
+        - userToken: []
+        - apiKey: []
+      parameters:
+        - in: query
+          name: title
+          description: Filter on the title of the task. Optional.
+          schema:
+            type: string
+        - in: query
+          name: limit
+          description: Limit the numer of tasks returned. Optional.
+          schema:
+            type: number
+            default: 1
+        - in: query
+          name: showCompleted
+          required: true
+          description: Flag indicating whether deleted tasks are returned in the result. Optional. The default is False.
+          schema:
+            type: boolean
+        - in: query
+          name: updatedAfter
+          description:
+            Lower bound for a task's last modification time (as a RFC 3339 timestamp) to filter by.
+            Optional. When used, `summary` and `showCompleted` are ignored.
+          schema:
+            type: string
+            format: datetime
+        - in: query
+          name: serviceName
+          description: Required for external tasks. Optional. By default returns Morgen tasks.
+          schema:
+            type: string
+        - in: query
+          name: accountId
+          description: Required for external tasks. Optional. By default returns Morgen tasks.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  allOf:
+                    - "$ref": "#/components/schemas/DocumentId"
+                    - "$ref": "#/components/schemas/TaskContextId"
+                    - "$ref": "#/components/schemas/TaskProperties"
+
+  "/v2/tasks/create":
+    post:
+      operationId: createTaskV2
+      summary: Create a Morgen task
+      tags:
+        - Tasks
+      security:
+        - userToken: []
+        - apiKey: []
+      requestBody:
+        description: Create a task in Morgen
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: "#/components/schemas/TaskCreateProperties"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - "$ref": "#/components/schemas/DocumentId"
+                  - "$ref": "#/components/schemas/TaskContextId"
+
+  "/v2/tasks/update":
+    post:
+      operationId: updateTaskV2
+      summary: Update a task
+      tags:
+        - Tasks
+      security:
+        - userToken: []
+        - apiKey: []
+      requestBody:
+        description: A task patch object. All properties are optional. Only "status" can be updated for external tasks.
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+                - "$ref": "#/components/schemas/DocumentId"
+                - "$ref": "#/components/schemas/TaskContextId"
+                - "$ref": "#/components/schemas/TaskProperties"
+      responses:
+        "204":
+          description: OK
+
+  "/v2/tasks/delete":
+    post:
+      operationId: deleteTaskV2
+      summary: Delete a task
+      tags:
+        - Tasks
+      security:
+        - userToken: [ ]
+        - apiKey: [ ]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+                - "$ref": "#/components/schemas/DocumentId"
+      responses:
+        "204":
+          description: OK
+
+  "/v2/tasks/close":
+    post:
+      operationId: closeTaskV2
+      summary: Close a task
+      tags:
+        - Tasks
+      security:
+        - userToken: []
+        - apiKey: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+                - "$ref": "#/components/schemas/DocumentId"
+                - "$ref": "#/components/schemas/TaskContextId"
+      responses:
+        "204":
+          description: OK
+
+  "/v2/tasks/reopen":
+    post:
+      operationId: reopenTaskV2
+      summary: Reopen a task
+      tags:
+        - Tasks
+      security:
+        - userToken: []
+        - apiKey: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+                - "$ref": "#/components/schemas/TaskContextId"
+                - "$ref": "#/components/schemas/DocumentId"
+      responses:
+        "204":
+          description: OK
+
+  "/v2/taskLists/list":
+    get:
+      operationId: listTaskListsV2
+      summary: Retrieve task lists
+      description:
+        Retrieve task lists from Morgen or third-party tasks providers (e.g. Todoist).
+        Notice that the notion of a list might map to a different entity on other providers.
+      tags:
+        - Task Lists
+      security:
+        - userToken: []
+        - apiKey: []
+      parameters:
+        - in: query
+          name: title
+          schema:
+            type: string
+        - in: query
+          name: limit
+          schema:
+            type: number
+            default: 1
+        - in: query
+          name: updatedAfter
+          description:
+            Lower bound for a task list's last modification time (as a RFC 3339 timestamp) to filter by.
+            Optional. When used, `summary` is ignored.
+          schema:
+            type: string
+            format: datetime
+        - in: query
+          name: serviceName
+          description: Required for external task services
+          schema:
+            type: string
+        - in: query
+          name: accountId
+          description: Required for external task services
+          schema:
+            type: string
+
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  allOf:
+                    - $ref: "#/components/schemas/DocumentId"
+                    - $ref: "#/components/schemas/TaskListContextId"
+                    - $ref: "#/components/schemas/TaskListProperty"
+
+  "/v2/taskLists/create":
+    post:
+      operationId: createTaskListV2
+      summary: Create a task list in Morgen
+      description: Create a new task list in Morgen. Currently it is not possible to create lists on third-party task apps with this API.
+      tags:
+        - Task Lists
+      security:
+        - userToken: []
+        - apiKey: []
+      requestBody:
+        description: A task list
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: "#/components/schemas/TaskListProperty"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/DocumentId"
+                  - $ref: "#/components/schemas/TaskListContextId"
+
+  "/v2/taskLists/update":
+    post:
+      operationId: updateTaskListV2
+      summary: Update a task list in Morgen
+      description: Update a Morgen task list.
+      tags:
+        - Task Lists
+      security:
+        - userToken: [ ]
+        - apiKey: [ ]
+      requestBody:
+        description: A task list
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: "#/components/schemas/DocumentId"
+                - $ref: "#/components/schemas/TaskListUpdateProperty"
+      responses:
+        "204":
+          description: OK
+
+  "/v2/taskLists/delete":
+    post:
+      operationId: deleteTaskListV2
+      summary: Delete a task list
+      tags:
+        - Task Lists
+      security:
+        - userToken: [ ]
+        - apiKey: [ ]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+                - "$ref": "#/components/schemas/DocumentId"
+      responses:
+        "204":
+          description: OK
+
+components:
+  securitySchemes:
+    userToken:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+    apiKey:
+      type: apiKey
+      in: header
+      name: Authorization
+      description: Use format "ApiKey XXXXXXXXXX"
+
+  responses:
+    UnauthorizedError:
+      description: Credentials missing or invalid
+
+  schemas:
+    DocumentId:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+
+    EventContextId:
+      type: object
+      required:
+        - calendarId
+        - accountId
+      properties:
+        calendarId:
+          type: string
+        accountId:
+          type: string
+
+    EventPropertiesImmutable:
+      type: object
+      properties:
+        # TODO: Add other IDs
+        uid:
+          type: string
+        serviceName:
+          type: string
+          enum:
+            - google
+            - o365
+
+    EventProperties:
+      type: object
+      properties:
+        title:
+          type: string
+        description:
+          type: string
+        locations:
+          type: object
+          additionalProperties:
+            type: object
+            properties:
+              name:
+                type: string
+        start:
+          # TODO: Mark as ISO datetime string
+          type: string
+          description: ISO datetime string, with no time zone information e.g. "2023-09-04T15:11:22"
+        duration:
+          # TODO: Mark as ISO duration string
+          type: string
+          description: ISO duration string e.g. "PT10M"
+        timeZone:
+          type: string
+          description: ISO timezone e.g. "Europe/Zurich"
+        showWithoutTime:
+          type: boolean
+          description: If true, this is an all-day event
+        participants:
+          type: object
+          # TODO: Specify JSCalendar participants here
+        #status:
+        #  type: string
+        #  enum:
+        #    - confirmed
+        #    - tentative
+        #    - cancelled
+        freeBusyStatus:
+          description: Indicates whether the participants are available during the event.
+          type: string
+          # TODO: Expand these
+          enum:
+            - free
+            - busy
+            - ooo
+        privacy:
+          type: string
+          enum:
+            - public
+            - private
+        "morgen.so:metadata":
+          type: object
+          properties:
+            taskId:
+              type: string
+
+    TaskContextId:
+      type: object
+      properties:
+        serviceName:
+          description: Required for external tasks
+          type: string
+        accountId:
+          description: Required for external tasks
+          type: string
+
+    TaskCreateProperties:
+      type: object
+      required:
+        - title
+      properties:
+        title:
+          type: string
+        description:
+          type: string
+        descriptionContentType:
+          type: string
+          enum:
+            - text/plain
+            - text/html
+        due:
+          type: string
+        estimatedDuration:
+          type: string
+        priority:
+          type: number
+          maximum: 9
+          minimum: 0
+        progress:
+          type: string
+          enum:
+            - needs-action
+            - completed
+        taskListId:
+          type: string
+
+    TaskProperties:
+      type: object
+      properties:
+        title:
+          type: string
+        description:
+          type: string
+        descriptionContentType:
+          type: string
+          enum:
+            - text/plain
+            - text/html
+        due:
+          type: string
+        estimatedDuration:
+          type: string
+        priority:
+          type: number
+          maximum: 9
+          minimum: 0
+        progress:
+          type: string
+          enum:
+            - needs-action
+            - completed
+        position:
+          type: number
+        taskListId:
+          type: string
+
+    CalendarContextId:
+      type: object
+      required:
+        - serviceName
+        - accountId
+      properties:
+        serviceName:
+          type: string
+        accountId:
+          type: string
+
+    CalendarProperties:
+      type: object
+      properties:
+        name:
+          type: string
+        color:
+          type: string
+        defaultAlertsWithoutTime:
+          type: object
+        defaultAlertsWithTime:
+          type: object
+        'morgen.so:metadata':
+          type: object
+          properties:
+            busy:
+              type: boolean
+              description: Indiciates whether an event in this calendar represents an interval where the user is busy.
+
+    TaskListProperty:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+        color:
+          type: string
+
+    TaskListUpdateProperty:
+      type: object
+      required:
+        # TODO: Not sure why this is mandatory, but it is
+        - name
+      properties:
+        name:
+          type: string
+        color:
+          type: string
+
+    TaskListContextId:
+      type: object
+      properties:
+        serviceName:
+          description: Required for external tasks
+          type: string
+        accountId:
+          description: Required for external tasks
+          type: string
+
+    UserPropertiesImmutable:
+      # TODO: Add more fields here
+      type: object
+      properties:
+        username:
+          type: string
+        email:
+          type: string
+
+    UserProperties:
+      type: object
+      properties:
+        firstName:
+          type: string
+        lastName:
+          type: string
+        company:
+          type: string
+
+    IntegrationGroups:
+      type: array
+      items:
+        properties:
+          type:
+            type: string
+            enum:
+              - webhooks
+              - video_conf
+              - tasks
+          displayName:
+            type: string
+
+    Integrations:
+      type: array
+      items:
+        type: object
+        properties:
+          id:
+            type: string
+          authId:
+            type: string
+          displayName:
+            type: string
+          iconData:
+            type: string
+
+
+
+    AccountProperties:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Morgen ID for the account object
+        integrationId:
+          type: string
+          description: The identifier of the third-party service
+        providerId:
+          type: string
+          description: The user account id for the third-party service
+        providerUserId:
+          type: string
+          description: The user id on the third-party service
+
+

--- a/openapi.v3.yaml
+++ b/openapi.v3.yaml
@@ -148,9 +148,9 @@ paths:
                         type: array
                         items:
                           allOf:
-                            - $ref: "#/components/schemas/CalendarProperties"
-                            - $ref: "#/components/schemas/CalendarContextId"
                             - $ref: "#/components/schemas/DocumentId"
+                            - $ref: "#/components/schemas/CalendarContextId"
+                            - $ref: "#/components/schemas/CalendarProperties"
 
   "/v3/calendars/update":
     post:
@@ -162,24 +162,15 @@ paths:
         - userToken: []
         - apiKey: []
       requestBody:
-        description: An event object
+        description: An calendar update object
         required: true
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                id:
-                  type: string
-                  description: The ID of the calendar to update
-                accountId:
-                  type: string
-                  description: The account ID of the calendar to update
-                'morgen.so:metadata':
-                  type: object
-                  properties:
-                    busy:
-                      type: boolean
+              allOf:
+                - $ref: "#/components/schemas/DocumentId"
+                - $ref: "#/components/schemas/CalendarContextId"
+                - $ref: "#/components/schemas/CalendarProperties"
       responses:
         "204":
           description: Update successful
@@ -821,7 +812,17 @@ components:
           properties:
             busy:
               type: boolean
-              description: Indiciates whether an event in this calendar represents an interval where the user is busy.
+              description: Indiciates whether an event in this calendar
+                represents an interval where the user is busy.
+            overrideName:
+              type: string
+              description: Name of the calendar as provided in the Morgen
+                interface, overriding the name provided by the external
+                provider
+            overrideColor:
+              type: string
+              description: Hex color as provided in the Morgen interface,
+                overriding the color provided by the external provider
 
     TaskListProperty:
       type: object

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       "devDependencies": {
         "@types/jest": "^29.5.5",
         "jest": "^29.7.0",
+        "openapi-typescript-codegen": "^0.25.0",
         "ts-jest": "^29.1.1"
       }
     },
@@ -31,6 +32,18 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
+      "integrity": "sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==",
+      "dev": true,
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -671,6 +684,37 @@
         "node": ">=8"
       }
     },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
@@ -1006,6 +1050,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "dev": true
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -1087,18 +1137,18 @@
       "dev": true
     },
     "node_modules/@types/istanbul-lib-report": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
-      "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-gPQuzaPR5h/djlAv2apEG1HVOyj1IUs7GpfMZixU0/0KXT3pm64ylHuMUI1/Akh+sq/iikxg6Z2j+fcMDXaaTQ==",
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-coverage": "*"
       }
     },
     "node_modules/@types/istanbul-reports": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz",
-      "integrity": "sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
+      "integrity": "sha512-kv43F9eb3Lhj+lr/Hn6OcLCs/sSM8bt+fIaP11rCYngfV6NVjzWXJ17owQtDQTL9tQ8WSLUrGsSJ6rJz0F1w1A==",
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
@@ -1113,6 +1163,12 @@
         "expect": "^29.0.0",
         "pretty-format": "^29.0.0"
       }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.13",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.13.tgz",
+      "integrity": "sha512-RbSSoHliUbnXj3ny0CNFOoxrIDV6SUGyStHsvDqosw6CkdPV8TtWGlfecuK4ToyMEAql6pzNxgCFKanovUzlgQ==",
+      "dev": true
     },
     "node_modules/@types/luxon": {
       "version": "3.3.2",
@@ -1198,13 +1254,10 @@
       }
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -1400,6 +1453,12 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+      "dev": true
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1410,12 +1469,15 @@
       }
     },
     "node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "dev": true,
       "engines": {
-        "node": ">=6"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/caniuse-lite": {
@@ -1532,6 +1594,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/commander": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.0.0.tgz",
+      "integrity": "sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1638,9 +1709,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.528",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.528.tgz",
-      "integrity": "sha512-UdREXMXzLkREF4jA8t89FQjA8WHI6ssP38PMY4/4KhXFQbtImnghh4GkCgrtiZwLKUKVD2iTVXvDVQjfomEQuA==",
+      "version": "1.4.529",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.529.tgz",
+      "integrity": "sha512-6uyPyXTo8lkv8SWAmjKFbG42U073TXlzD4R8rW3EzuznhFS2olCIAfjjQtV2dV2ar/vRF55KUd3zQYnCB0dd3A==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -1789,6 +1860,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/fs-extra": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1888,6 +1973,27 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -2658,18 +2764,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-validate/node_modules/camelcase": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/jest-watcher": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
@@ -2726,13 +2820,12 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
@@ -2756,6 +2849,19 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
+    "node_modules/json-schema-ref-parser": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
+      "integrity": "sha512-qcP2lmGy+JUoQJ4DOQeLaZDqH9qSkeGCK3suKWxJXS82dg728Mn3j97azDMaOUmJAN4uCq91LdPx4K7E8F1a7Q==",
+      "deprecated": "Please switch to @apidevtools/json-schema-ref-parser",
+      "dev": true,
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "9.0.9"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -2766,6 +2872,18 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/kleur": {
@@ -2930,6 +3048,15 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -2940,6 +3067,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
     "node_modules/node-int64": {
@@ -2997,6 +3130,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openapi-typescript-codegen": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/openapi-typescript-codegen/-/openapi-typescript-codegen-0.25.0.tgz",
+      "integrity": "sha512-nN/TnIcGbP58qYgwEEy5FrAAjePcYgfMaCe3tsmYyTgI3v4RR9v8os14L+LEWDvV50+CmqiyTzRkKKtJeb6Ybg==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^6.3.0",
+        "commander": "^11.0.0",
+        "fs-extra": "^11.1.1",
+        "handlebars": "^4.7.7",
+        "json-schema-ref-parser": "^9.0.9"
+      },
+      "bin": {
+        "openapi": "bin/index.js"
       }
     },
     "node_modules/p-limit": {
@@ -3590,6 +3739,28 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uglify-js": {
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
@@ -3663,6 +3834,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsc",
+    "build": "sh generate-openapi-client.sh && tsc",
     "postinstall": "tsc",
     "test": "jest"
   },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@types/jest": "^29.5.5",
     "jest": "^29.7.0",
-    "ts-jest": "^29.1.1"
+    "ts-jest": "^29.1.1",
+    "openapi-typescript-codegen": "^0.25.0"
   }
 }

--- a/src/generated/Morgen.ts
+++ b/src/generated/Morgen.ts
@@ -1,0 +1,50 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { BaseHttpRequest } from './core/BaseHttpRequest';
+import type { OpenAPIConfig } from './core/OpenAPI';
+import { FetchHttpRequest } from './core/FetchHttpRequest';
+
+import { AccountsService } from './services/AccountsService';
+import { CalendarsService } from './services/CalendarsService';
+import { EventsService } from './services/EventsService';
+import { TaskListsService } from './services/TaskListsService';
+import { TasksService } from './services/TasksService';
+import { UserService } from './services/UserService';
+
+type HttpRequestConstructor = new (config: OpenAPIConfig) => BaseHttpRequest;
+
+export class Morgen {
+
+    public readonly accounts: AccountsService;
+    public readonly calendars: CalendarsService;
+    public readonly events: EventsService;
+    public readonly taskLists: TaskListsService;
+    public readonly tasks: TasksService;
+    public readonly user: UserService;
+
+    public readonly request: BaseHttpRequest;
+
+    constructor(config?: Partial<OpenAPIConfig>, HttpRequest: HttpRequestConstructor = FetchHttpRequest) {
+        this.request = new HttpRequest({
+            BASE: config?.BASE ?? 'https://api.morgen.so',
+            VERSION: config?.VERSION ?? '3.0.0',
+            WITH_CREDENTIALS: config?.WITH_CREDENTIALS ?? false,
+            CREDENTIALS: config?.CREDENTIALS ?? 'include',
+            TOKEN: config?.TOKEN,
+            USERNAME: config?.USERNAME,
+            PASSWORD: config?.PASSWORD,
+            HEADERS: config?.HEADERS,
+            ENCODE_PATH: config?.ENCODE_PATH,
+        });
+
+        this.accounts = new AccountsService(this.request);
+        this.calendars = new CalendarsService(this.request);
+        this.events = new EventsService(this.request);
+        this.taskLists = new TaskListsService(this.request);
+        this.tasks = new TasksService(this.request);
+        this.user = new UserService(this.request);
+    }
+}
+

--- a/src/generated/core/ApiError.ts
+++ b/src/generated/core/ApiError.ts
@@ -1,0 +1,25 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ApiRequestOptions } from './ApiRequestOptions';
+import type { ApiResult } from './ApiResult';
+
+export class ApiError extends Error {
+    public readonly url: string;
+    public readonly status: number;
+    public readonly statusText: string;
+    public readonly body: any;
+    public readonly request: ApiRequestOptions;
+
+    constructor(request: ApiRequestOptions, response: ApiResult, message: string) {
+        super(message);
+
+        this.name = 'ApiError';
+        this.url = response.url;
+        this.status = response.status;
+        this.statusText = response.statusText;
+        this.body = response.body;
+        this.request = request;
+    }
+}

--- a/src/generated/core/ApiRequestOptions.ts
+++ b/src/generated/core/ApiRequestOptions.ts
@@ -1,0 +1,17 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ApiRequestOptions = {
+    readonly method: 'GET' | 'PUT' | 'POST' | 'DELETE' | 'OPTIONS' | 'HEAD' | 'PATCH';
+    readonly url: string;
+    readonly path?: Record<string, any>;
+    readonly cookies?: Record<string, any>;
+    readonly headers?: Record<string, any>;
+    readonly query?: Record<string, any>;
+    readonly formData?: Record<string, any>;
+    readonly body?: any;
+    readonly mediaType?: string;
+    readonly responseHeader?: string;
+    readonly errors?: Record<number, string>;
+};

--- a/src/generated/core/ApiResult.ts
+++ b/src/generated/core/ApiResult.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ApiResult = {
+    readonly url: string;
+    readonly ok: boolean;
+    readonly status: number;
+    readonly statusText: string;
+    readonly body: any;
+};

--- a/src/generated/core/BaseHttpRequest.ts
+++ b/src/generated/core/BaseHttpRequest.ts
@@ -1,0 +1,14 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ApiRequestOptions } from './ApiRequestOptions';
+import type { CancelablePromise } from './CancelablePromise';
+import type { OpenAPIConfig } from './OpenAPI';
+
+export abstract class BaseHttpRequest {
+
+    constructor(public readonly config: OpenAPIConfig) {}
+
+    public abstract request<T>(options: ApiRequestOptions): CancelablePromise<T>;
+}

--- a/src/generated/core/CancelablePromise.ts
+++ b/src/generated/core/CancelablePromise.ts
@@ -1,0 +1,131 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export class CancelError extends Error {
+
+    constructor(message: string) {
+        super(message);
+        this.name = 'CancelError';
+    }
+
+    public get isCancelled(): boolean {
+        return true;
+    }
+}
+
+export interface OnCancel {
+    readonly isResolved: boolean;
+    readonly isRejected: boolean;
+    readonly isCancelled: boolean;
+
+    (cancelHandler: () => void): void;
+}
+
+export class CancelablePromise<T> implements Promise<T> {
+    #isResolved: boolean;
+    #isRejected: boolean;
+    #isCancelled: boolean;
+    readonly #cancelHandlers: (() => void)[];
+    readonly #promise: Promise<T>;
+    #resolve?: (value: T | PromiseLike<T>) => void;
+    #reject?: (reason?: any) => void;
+
+    constructor(
+        executor: (
+            resolve: (value: T | PromiseLike<T>) => void,
+            reject: (reason?: any) => void,
+            onCancel: OnCancel
+        ) => void
+    ) {
+        this.#isResolved = false;
+        this.#isRejected = false;
+        this.#isCancelled = false;
+        this.#cancelHandlers = [];
+        this.#promise = new Promise<T>((resolve, reject) => {
+            this.#resolve = resolve;
+            this.#reject = reject;
+
+            const onResolve = (value: T | PromiseLike<T>): void => {
+                if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+                    return;
+                }
+                this.#isResolved = true;
+                this.#resolve?.(value);
+            };
+
+            const onReject = (reason?: any): void => {
+                if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+                    return;
+                }
+                this.#isRejected = true;
+                this.#reject?.(reason);
+            };
+
+            const onCancel = (cancelHandler: () => void): void => {
+                if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+                    return;
+                }
+                this.#cancelHandlers.push(cancelHandler);
+            };
+
+            Object.defineProperty(onCancel, 'isResolved', {
+                get: (): boolean => this.#isResolved,
+            });
+
+            Object.defineProperty(onCancel, 'isRejected', {
+                get: (): boolean => this.#isRejected,
+            });
+
+            Object.defineProperty(onCancel, 'isCancelled', {
+                get: (): boolean => this.#isCancelled,
+            });
+
+            return executor(onResolve, onReject, onCancel as OnCancel);
+        });
+    }
+
+     get [Symbol.toStringTag]() {
+            return "Cancellable Promise";
+     }
+
+    public then<TResult1 = T, TResult2 = never>(
+        onFulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | null,
+        onRejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null
+    ): Promise<TResult1 | TResult2> {
+        return this.#promise.then(onFulfilled, onRejected);
+    }
+
+    public catch<TResult = never>(
+        onRejected?: ((reason: any) => TResult | PromiseLike<TResult>) | null
+    ): Promise<T | TResult> {
+        return this.#promise.catch(onRejected);
+    }
+
+    public finally(onFinally?: (() => void) | null): Promise<T> {
+        return this.#promise.finally(onFinally);
+    }
+
+    public cancel(): void {
+        if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+            return;
+        }
+        this.#isCancelled = true;
+        if (this.#cancelHandlers.length) {
+            try {
+                for (const cancelHandler of this.#cancelHandlers) {
+                    cancelHandler();
+                }
+            } catch (error) {
+                console.warn('Cancellation threw an error', error);
+                return;
+            }
+        }
+        this.#cancelHandlers.length = 0;
+        this.#reject?.(new CancelError('Request aborted'));
+    }
+
+    public get isCancelled(): boolean {
+        return this.#isCancelled;
+    }
+}

--- a/src/generated/core/FetchHttpRequest.ts
+++ b/src/generated/core/FetchHttpRequest.ts
@@ -1,0 +1,26 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ApiRequestOptions } from './ApiRequestOptions';
+import { BaseHttpRequest } from './BaseHttpRequest';
+import type { CancelablePromise } from './CancelablePromise';
+import type { OpenAPIConfig } from './OpenAPI';
+import { request as __request } from './request';
+
+export class FetchHttpRequest extends BaseHttpRequest {
+
+    constructor(config: OpenAPIConfig) {
+        super(config);
+    }
+
+    /**
+     * Request method
+     * @param options The request options from the service
+     * @returns CancelablePromise<T>
+     * @throws ApiError
+     */
+    public override request<T>(options: ApiRequestOptions): CancelablePromise<T> {
+        return __request(this.config, options);
+    }
+}

--- a/src/generated/core/OpenAPI.ts
+++ b/src/generated/core/OpenAPI.ts
@@ -1,0 +1,32 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ApiRequestOptions } from './ApiRequestOptions';
+
+type Resolver<T> = (options: ApiRequestOptions) => Promise<T>;
+type Headers = Record<string, string>;
+
+export type OpenAPIConfig = {
+    BASE: string;
+    VERSION: string;
+    WITH_CREDENTIALS: boolean;
+    CREDENTIALS: 'include' | 'omit' | 'same-origin';
+    TOKEN?: string | Resolver<string> | undefined;
+    USERNAME?: string | Resolver<string> | undefined;
+    PASSWORD?: string | Resolver<string> | undefined;
+    HEADERS?: Headers | Resolver<Headers> | undefined;
+    ENCODE_PATH?: ((path: string) => string) | undefined;
+};
+
+export const OpenAPI: OpenAPIConfig = {
+    BASE: 'https://api.morgen.so',
+    VERSION: '3.0.0',
+    WITH_CREDENTIALS: false,
+    CREDENTIALS: 'include',
+    TOKEN: undefined,
+    USERNAME: undefined,
+    PASSWORD: undefined,
+    HEADERS: undefined,
+    ENCODE_PATH: undefined,
+};

--- a/src/generated/core/request.ts
+++ b/src/generated/core/request.ts
@@ -1,0 +1,47 @@
+import type { ApiRequestOptions } from "./ApiRequestOptions";
+import type { OpenAPIConfig } from "./OpenAPI";
+import { CancelablePromise } from "./CancelablePromise";
+import { fetchJSON, log } from "../../global";
+
+/**
+ * Request method
+ * @param config The OpenAPI configuration object
+ * @param options The request options from the service
+ * @returns Promise<T>
+ * @throws ApiError
+ */
+export function request<T>(
+  config: OpenAPIConfig,
+  options: ApiRequestOptions
+): CancelablePromise<T> {
+  return new CancelablePromise(
+    async (
+      resolve: (successBody: T) => unknown,
+      reject: (e: Error) => void
+    ) => {
+      const { url, ...rest } = options || { headers: {} };
+      let queryString = "";
+
+      Object.keys(options?.query || {}).forEach((k) => {
+        if (!options.query[k]) return;
+        queryString = queryString + "&" + k + "=" + options.query[k];
+      });
+
+      const headers = rest.headers || {};
+      try {
+        const resp = await fetchJSON(config.BASE + url + "?" + queryString, {
+          ...rest,
+          headers: {
+            ...headers,
+            ...config.HEADERS,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(options.body),
+        });
+        resolve(resp.body);
+      } catch (e) {
+        reject(e);
+      }
+    }
+  );
+}

--- a/src/generated/core/request.ts
+++ b/src/generated/core/request.ts
@@ -1,7 +1,7 @@
 import type { ApiRequestOptions } from "./ApiRequestOptions";
 import type { OpenAPIConfig } from "./OpenAPI";
 import { CancelablePromise } from "./CancelablePromise";
-import { fetchJSON, log } from "../../global";
+import { fetchJSON } from "../../global";
 
 /**
  * Request method
@@ -35,6 +35,7 @@ export function request<T>(
             ...headers,
             ...config.HEADERS,
             "Content-Type": "application/json",
+            "User-Agent": `Morgen CW SDK (0.0.1)`,
           },
           body: JSON.stringify(options.body),
         });

--- a/src/generated/index.ts
+++ b/src/generated/index.ts
@@ -1,0 +1,36 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export { Morgen } from './Morgen';
+
+export { ApiError } from './core/ApiError';
+export { BaseHttpRequest } from './core/BaseHttpRequest';
+export { CancelablePromise, CancelError } from './core/CancelablePromise';
+export { OpenAPI } from './core/OpenAPI';
+export type { OpenAPIConfig } from './core/OpenAPI';
+
+export type { AccountProperties } from './models/AccountProperties';
+export type { CalendarContextId } from './models/CalendarContextId';
+export type { CalendarProperties } from './models/CalendarProperties';
+export type { DocumentId } from './models/DocumentId';
+export type { EventContextId } from './models/EventContextId';
+export { EventProperties } from './models/EventProperties';
+export { EventPropertiesImmutable } from './models/EventPropertiesImmutable';
+export type { IntegrationGroups } from './models/IntegrationGroups';
+export type { Integrations } from './models/Integrations';
+export type { TaskContextId } from './models/TaskContextId';
+export { TaskCreateProperties } from './models/TaskCreateProperties';
+export type { TaskListContextId } from './models/TaskListContextId';
+export type { TaskListProperty } from './models/TaskListProperty';
+export type { TaskListUpdateProperty } from './models/TaskListUpdateProperty';
+export { TaskProperties } from './models/TaskProperties';
+export type { UserProperties } from './models/UserProperties';
+export type { UserPropertiesImmutable } from './models/UserPropertiesImmutable';
+
+export { AccountsService } from './services/AccountsService';
+export { CalendarsService } from './services/CalendarsService';
+export { EventsService } from './services/EventsService';
+export { TaskListsService } from './services/TaskListsService';
+export { TasksService } from './services/TasksService';
+export { UserService } from './services/UserService';

--- a/src/generated/models/AccountProperties.ts
+++ b/src/generated/models/AccountProperties.ts
@@ -1,0 +1,24 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type AccountProperties = {
+    /**
+     * Morgen ID for the account object
+     */
+    id?: string;
+    /**
+     * The identifier of the third-party service
+     */
+    integrationId?: string;
+    /**
+     * The user account id for the third-party service
+     */
+    providerId?: string;
+    /**
+     * The user id on the third-party service
+     */
+    providerUserId?: string;
+};
+

--- a/src/generated/models/CalendarContextId.ts
+++ b/src/generated/models/CalendarContextId.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type CalendarContextId = {
+    serviceName: string;
+    accountId: string;
+};
+

--- a/src/generated/models/CalendarProperties.ts
+++ b/src/generated/models/CalendarProperties.ts
@@ -13,6 +13,14 @@ export type CalendarProperties = {
          * Indiciates whether an event in this calendar represents an interval where the user is busy.
          */
         busy?: boolean;
+        /**
+         * Name of the calendar as provided in the Morgen interface, overriding the name provided by the external provider
+         */
+        overrideName?: string;
+        /**
+         * Hex color as provided in the Morgen interface, overriding the color provided by the external provider
+         */
+        overrideColor?: string;
     };
 };
 

--- a/src/generated/models/CalendarProperties.ts
+++ b/src/generated/models/CalendarProperties.ts
@@ -1,0 +1,18 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type CalendarProperties = {
+    name?: string;
+    color?: string;
+    defaultAlertsWithoutTime?: Record<string, any>;
+    defaultAlertsWithTime?: Record<string, any>;
+    'morgen.so:metadata'?: {
+        /**
+         * Indiciates whether an event in this calendar represents an interval where the user is busy.
+         */
+        busy?: boolean;
+    };
+};
+

--- a/src/generated/models/DocumentId.ts
+++ b/src/generated/models/DocumentId.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type DocumentId = {
+    id: string;
+};
+

--- a/src/generated/models/EventContextId.ts
+++ b/src/generated/models/EventContextId.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type EventContextId = {
+    calendarId: string;
+    accountId: string;
+};
+

--- a/src/generated/models/EventProperties.ts
+++ b/src/generated/models/EventProperties.ts
@@ -1,0 +1,57 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type EventProperties = {
+    title?: string;
+    description?: string;
+    locations?: Record<string, {
+        name?: string;
+    }>;
+    /**
+     * ISO datetime string, with no time zone information e.g. "2023-09-04T15:11:22"
+     */
+    start?: string;
+    /**
+     * ISO duration string e.g. "PT10M"
+     */
+    duration?: string;
+    /**
+     * ISO timezone e.g. "Europe/Zurich"
+     */
+    timeZone?: string;
+    /**
+     * If true, this is an all-day event
+     */
+    showWithoutTime?: boolean;
+    participants?: Record<string, any>;
+    /**
+     * Indicates whether the participants are available during the event.
+     */
+    freeBusyStatus?: EventProperties.freeBusyStatus;
+    privacy?: EventProperties.privacy;
+    'morgen.so:metadata'?: {
+        taskId?: string;
+    };
+};
+
+export namespace EventProperties {
+
+    /**
+     * Indicates whether the participants are available during the event.
+     */
+    export enum freeBusyStatus {
+        FREE = 'free',
+        BUSY = 'busy',
+        OOO = 'ooo',
+    }
+
+    export enum privacy {
+        PUBLIC = 'public',
+        PRIVATE = 'private',
+    }
+
+
+}
+

--- a/src/generated/models/EventPropertiesImmutable.ts
+++ b/src/generated/models/EventPropertiesImmutable.ts
@@ -1,0 +1,20 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type EventPropertiesImmutable = {
+    uid?: string;
+    serviceName?: EventPropertiesImmutable.serviceName;
+};
+
+export namespace EventPropertiesImmutable {
+
+    export enum serviceName {
+        GOOGLE = 'google',
+        O365 = 'o365',
+    }
+
+
+}
+

--- a/src/generated/models/IntegrationGroups.ts
+++ b/src/generated/models/IntegrationGroups.ts
@@ -1,0 +1,6 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type IntegrationGroups = Array<any>;

--- a/src/generated/models/Integrations.ts
+++ b/src/generated/models/Integrations.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type Integrations = Array<{
+    id?: string;
+    authId?: string;
+    displayName?: string;
+    iconData?: string;
+}>;

--- a/src/generated/models/TaskContextId.ts
+++ b/src/generated/models/TaskContextId.ts
@@ -1,0 +1,16 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type TaskContextId = {
+    /**
+     * Required for external tasks
+     */
+    serviceName?: string;
+    /**
+     * Required for external tasks
+     */
+    accountId?: string;
+};
+

--- a/src/generated/models/TaskCreateProperties.ts
+++ b/src/generated/models/TaskCreateProperties.ts
@@ -1,0 +1,31 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type TaskCreateProperties = {
+    title: string;
+    description?: string;
+    descriptionContentType?: TaskCreateProperties.descriptionContentType;
+    due?: string;
+    estimatedDuration?: string;
+    priority?: number;
+    progress?: TaskCreateProperties.progress;
+    taskListId?: string;
+};
+
+export namespace TaskCreateProperties {
+
+    export enum descriptionContentType {
+        TEXT_PLAIN = 'text/plain',
+        TEXT_HTML = 'text/html',
+    }
+
+    export enum progress {
+        NEEDS_ACTION = 'needs-action',
+        COMPLETED = 'completed',
+    }
+
+
+}
+

--- a/src/generated/models/TaskListContextId.ts
+++ b/src/generated/models/TaskListContextId.ts
@@ -1,0 +1,16 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type TaskListContextId = {
+    /**
+     * Required for external tasks
+     */
+    serviceName?: string;
+    /**
+     * Required for external tasks
+     */
+    accountId?: string;
+};
+

--- a/src/generated/models/TaskListProperty.ts
+++ b/src/generated/models/TaskListProperty.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type TaskListProperty = {
+    name: string;
+    color?: string;
+};
+

--- a/src/generated/models/TaskListUpdateProperty.ts
+++ b/src/generated/models/TaskListUpdateProperty.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type TaskListUpdateProperty = {
+    name: string;
+    color?: string;
+};
+

--- a/src/generated/models/TaskProperties.ts
+++ b/src/generated/models/TaskProperties.ts
@@ -1,0 +1,32 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type TaskProperties = {
+    title?: string;
+    description?: string;
+    descriptionContentType?: TaskProperties.descriptionContentType;
+    due?: string;
+    estimatedDuration?: string;
+    priority?: number;
+    progress?: TaskProperties.progress;
+    position?: number;
+    taskListId?: string;
+};
+
+export namespace TaskProperties {
+
+    export enum descriptionContentType {
+        TEXT_PLAIN = 'text/plain',
+        TEXT_HTML = 'text/html',
+    }
+
+    export enum progress {
+        NEEDS_ACTION = 'needs-action',
+        COMPLETED = 'completed',
+    }
+
+
+}
+

--- a/src/generated/models/UserProperties.ts
+++ b/src/generated/models/UserProperties.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type UserProperties = {
+    firstName?: string;
+    lastName?: string;
+    company?: string;
+};
+

--- a/src/generated/models/UserPropertiesImmutable.ts
+++ b/src/generated/models/UserPropertiesImmutable.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type UserPropertiesImmutable = {
+    username?: string;
+    email?: string;
+};
+

--- a/src/generated/services/AccountsService.ts
+++ b/src/generated/services/AccountsService.ts
@@ -1,0 +1,50 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { AccountProperties } from '../models/AccountProperties';
+import type { IntegrationGroups } from '../models/IntegrationGroups';
+import type { Integrations } from '../models/Integrations';
+
+import type { CancelablePromise } from '../core/CancelablePromise';
+import type { BaseHttpRequest } from '../core/BaseHttpRequest';
+
+export class AccountsService {
+
+    constructor(public readonly httpRequest: BaseHttpRequest) {}
+
+    /**
+     * Get a list of supported services
+     * @returns any OK
+     * @throws ApiError
+     */
+    public listIntegrationsV3(): CancelablePromise<{
+        data?: {
+            groups?: IntegrationGroups;
+            integrations?: Integrations;
+        };
+    }> {
+        return this.httpRequest.request({
+            method: 'GET',
+            url: '/v3/integrations/list',
+        });
+    }
+
+    /**
+     * Retrieve accounts list
+     * Retrieve a list of accounts the user has access to
+     * @returns any OK
+     * @throws ApiError
+     */
+    public listAccountsV3(): CancelablePromise<{
+        data?: {
+            accounts?: Array<AccountProperties>;
+        };
+    }> {
+        return this.httpRequest.request({
+            method: 'GET',
+            url: '/v3/integrations/accounts/list',
+        });
+    }
+
+}

--- a/src/generated/services/CalendarsService.ts
+++ b/src/generated/services/CalendarsService.ts
@@ -1,0 +1,68 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { AccountProperties } from '../models/AccountProperties';
+import type { CalendarContextId } from '../models/CalendarContextId';
+import type { CalendarProperties } from '../models/CalendarProperties';
+import type { DocumentId } from '../models/DocumentId';
+
+import type { CancelablePromise } from '../core/CancelablePromise';
+import type { BaseHttpRequest } from '../core/BaseHttpRequest';
+
+export class CalendarsService {
+
+    constructor(public readonly httpRequest: BaseHttpRequest) {}
+
+    /**
+     * Retrieve a list of calendars the user has access to
+     * List all the calendars connected to Morgen.
+     * @returns any OK
+     * @throws ApiError
+     */
+    public listCalendarsV3(): CancelablePromise<{
+        data?: {
+            accounts?: Array<AccountProperties>;
+            calendars?: Array<(CalendarProperties & CalendarContextId & DocumentId)>;
+        };
+    }> {
+        return this.httpRequest.request({
+            method: 'GET',
+            url: '/v3/calendars/list',
+        });
+    }
+
+    /**
+     * Update calendar metadata
+     * @returns void
+     * @throws ApiError
+     */
+    public updateCalendarMetadataV3({
+        requestBody,
+    }: {
+        /**
+         * An event object
+         */
+        requestBody: {
+            /**
+             * The ID of the calendar to update
+             */
+            id?: string;
+            /**
+             * The account ID of the calendar to update
+             */
+            accountId?: string;
+            'morgen.so:metadata'?: {
+                busy?: boolean;
+            };
+        },
+    }): CancelablePromise<void> {
+        return this.httpRequest.request({
+            method: 'POST',
+            url: '/v3/calendars/update',
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+
+}

--- a/src/generated/services/CalendarsService.ts
+++ b/src/generated/services/CalendarsService.ts
@@ -23,7 +23,7 @@ export class CalendarsService {
     public listCalendarsV3(): CancelablePromise<{
         data?: {
             accounts?: Array<AccountProperties>;
-            calendars?: Array<(CalendarProperties & CalendarContextId & DocumentId)>;
+            calendars?: Array<(DocumentId & CalendarContextId & CalendarProperties)>;
         };
     }> {
         return this.httpRequest.request({
@@ -41,21 +41,9 @@ export class CalendarsService {
         requestBody,
     }: {
         /**
-         * An event object
+         * An calendar update object
          */
-        requestBody: {
-            /**
-             * The ID of the calendar to update
-             */
-            id?: string;
-            /**
-             * The account ID of the calendar to update
-             */
-            accountId?: string;
-            'morgen.so:metadata'?: {
-                busy?: boolean;
-            };
-        },
+        requestBody: (DocumentId & CalendarContextId & CalendarProperties),
     }): CancelablePromise<void> {
         return this.httpRequest.request({
             method: 'POST',

--- a/src/generated/services/EventsService.ts
+++ b/src/generated/services/EventsService.ts
@@ -1,0 +1,123 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { DocumentId } from '../models/DocumentId';
+import type { EventContextId } from '../models/EventContextId';
+import type { EventProperties } from '../models/EventProperties';
+import type { EventPropertiesImmutable } from '../models/EventPropertiesImmutable';
+
+import type { CancelablePromise } from '../core/CancelablePromise';
+import type { BaseHttpRequest } from '../core/BaseHttpRequest';
+
+export class EventsService {
+
+    constructor(public readonly httpRequest: BaseHttpRequest) {}
+
+    /**
+     * Retrieve events from all calendars
+     * Retrieve events from all connected calendars, occurring within a given a [`start`, `end`] time window.
+     *
+     * @returns any OK
+     * @throws ApiError
+     */
+    public listEventsV3({
+        start,
+        end,
+        accountId,
+        calendarIds,
+    }: {
+        start: string,
+        end: string,
+        accountId: string,
+        /**
+         * If a `calendarIds` is specific, only events in the corresponding calendar are returned. To filter for multiple calendars, use calendar ids separated by a comma, i.e. "calendarId_1,calendarId_2".
+         *
+         */
+        calendarIds?: string,
+    }): CancelablePromise<{
+        data?: {
+            events?: Array<(EventProperties & EventContextId & DocumentId)>;
+        };
+    }> {
+        return this.httpRequest.request({
+            method: 'GET',
+            url: '/v3/events/list',
+            query: {
+                'start': start,
+                'end': end,
+                'accountId': accountId,
+                'calendarIds': calendarIds,
+            },
+        });
+    }
+
+    /**
+     * Create a calendar event
+     * @returns any OK
+     * @throws ApiError
+     */
+    public createEventV3({
+        requestBody,
+    }: {
+        /**
+         * An event object
+         */
+        requestBody: (EventContextId & EventProperties),
+    }): CancelablePromise<(EventContextId & EventPropertiesImmutable & EventProperties & DocumentId & {
+        /**
+         * If specified, a virtual video conferencing room will be added to the event. Only supported for O365/Google events.
+         */
+        'morgen.so:requestVirtualRoom'?: 'default';
+    })> {
+        return this.httpRequest.request({
+            method: 'POST',
+            url: '/v3/events/create',
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+
+    /**
+     * Update a calendar event
+     * @returns void
+     * @throws ApiError
+     */
+    public updateEventV3({
+        requestBody,
+    }: {
+        /**
+         * An event object
+         */
+        requestBody: (DocumentId & EventContextId & EventProperties),
+    }): CancelablePromise<void> {
+        return this.httpRequest.request({
+            method: 'POST',
+            url: '/v3/events/update',
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+
+    /**
+     * Delete a calendar event
+     * @returns void
+     * @throws ApiError
+     */
+    public deleteEventV3({
+        requestBody,
+    }: {
+        /**
+         * The identifier of the event to delete
+         */
+        requestBody: (EventContextId & DocumentId),
+    }): CancelablePromise<void> {
+        return this.httpRequest.request({
+            method: 'POST',
+            url: '/v3/events/delete',
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+
+}

--- a/src/generated/services/TaskListsService.ts
+++ b/src/generated/services/TaskListsService.ts
@@ -1,0 +1,120 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { DocumentId } from '../models/DocumentId';
+import type { TaskListContextId } from '../models/TaskListContextId';
+import type { TaskListProperty } from '../models/TaskListProperty';
+import type { TaskListUpdateProperty } from '../models/TaskListUpdateProperty';
+
+import type { CancelablePromise } from '../core/CancelablePromise';
+import type { BaseHttpRequest } from '../core/BaseHttpRequest';
+
+export class TaskListsService {
+
+    constructor(public readonly httpRequest: BaseHttpRequest) {}
+
+    /**
+     * Retrieve task lists
+     * Retrieve task lists from Morgen or third-party tasks providers (e.g. Todoist). Notice that the notion of a list might map to a different entity on other providers.
+     * @returns any OK
+     * @throws ApiError
+     */
+    public listTaskListsV2({
+        title,
+        limit = 1,
+        updatedAfter,
+        serviceName,
+        accountId,
+    }: {
+        title?: string,
+        limit?: number,
+        /**
+         * Lower bound for a task list's last modification time (as a RFC 3339 timestamp) to filter by. Optional. When used, `summary` is ignored.
+         */
+        updatedAfter?: string,
+        /**
+         * Required for external task services
+         */
+        serviceName?: string,
+        /**
+         * Required for external task services
+         */
+        accountId?: string,
+    }): CancelablePromise<Array<(DocumentId & TaskListContextId & TaskListProperty)>> {
+        return this.httpRequest.request({
+            method: 'GET',
+            url: '/v2/taskLists/list',
+            query: {
+                'title': title,
+                'limit': limit,
+                'updatedAfter': updatedAfter,
+                'serviceName': serviceName,
+                'accountId': accountId,
+            },
+        });
+    }
+
+    /**
+     * Create a task list in Morgen
+     * Create a new task list in Morgen. Currently it is not possible to create lists on third-party task apps with this API.
+     * @returns any OK
+     * @throws ApiError
+     */
+    public createTaskListV2({
+        requestBody,
+    }: {
+        /**
+         * A task list
+         */
+        requestBody: TaskListProperty,
+    }): CancelablePromise<(DocumentId & TaskListContextId)> {
+        return this.httpRequest.request({
+            method: 'POST',
+            url: '/v2/taskLists/create',
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+
+    /**
+     * Update a task list in Morgen
+     * Update a Morgen task list.
+     * @returns void
+     * @throws ApiError
+     */
+    public updateTaskListV2({
+        requestBody,
+    }: {
+        /**
+         * A task list
+         */
+        requestBody: (DocumentId & TaskListUpdateProperty),
+    }): CancelablePromise<void> {
+        return this.httpRequest.request({
+            method: 'POST',
+            url: '/v2/taskLists/update',
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+
+    /**
+     * Delete a task list
+     * @returns void
+     * @throws ApiError
+     */
+    public deleteTaskListV2({
+        requestBody,
+    }: {
+        requestBody: DocumentId,
+    }): CancelablePromise<void> {
+        return this.httpRequest.request({
+            method: 'POST',
+            url: '/v2/taskLists/delete',
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+
+}

--- a/src/generated/services/TasksService.ts
+++ b/src/generated/services/TasksService.ts
@@ -1,0 +1,165 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { DocumentId } from '../models/DocumentId';
+import type { TaskContextId } from '../models/TaskContextId';
+import type { TaskCreateProperties } from '../models/TaskCreateProperties';
+import type { TaskProperties } from '../models/TaskProperties';
+
+import type { CancelablePromise } from '../core/CancelablePromise';
+import type { BaseHttpRequest } from '../core/BaseHttpRequest';
+
+export class TasksService {
+
+    constructor(public readonly httpRequest: BaseHttpRequest) {}
+
+    /**
+     * Retrieve tasks
+     * @returns any OK
+     * @throws ApiError
+     */
+    public listTasksV2({
+        showCompleted,
+        title,
+        limit = 1,
+        updatedAfter,
+        serviceName,
+        accountId,
+    }: {
+        /**
+         * Flag indicating whether deleted tasks are returned in the result. Optional. The default is False.
+         */
+        showCompleted: boolean,
+        /**
+         * Filter on the title of the task. Optional.
+         */
+        title?: string,
+        /**
+         * Limit the numer of tasks returned. Optional.
+         */
+        limit?: number,
+        /**
+         * Lower bound for a task's last modification time (as a RFC 3339 timestamp) to filter by. Optional. When used, `summary` and `showCompleted` are ignored.
+         */
+        updatedAfter?: string,
+        /**
+         * Required for external tasks. Optional. By default returns Morgen tasks.
+         */
+        serviceName?: string,
+        /**
+         * Required for external tasks. Optional. By default returns Morgen tasks.
+         */
+        accountId?: string,
+    }): CancelablePromise<Array<(DocumentId & TaskContextId & TaskProperties)>> {
+        return this.httpRequest.request({
+            method: 'GET',
+            url: '/v2/tasks/list',
+            query: {
+                'title': title,
+                'limit': limit,
+                'showCompleted': showCompleted,
+                'updatedAfter': updatedAfter,
+                'serviceName': serviceName,
+                'accountId': accountId,
+            },
+        });
+    }
+
+    /**
+     * Create a Morgen task
+     * @returns any OK
+     * @throws ApiError
+     */
+    public createTaskV2({
+        requestBody,
+    }: {
+        /**
+         * Create a task in Morgen
+         */
+        requestBody: TaskCreateProperties,
+    }): CancelablePromise<(DocumentId & TaskContextId)> {
+        return this.httpRequest.request({
+            method: 'POST',
+            url: '/v2/tasks/create',
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+
+    /**
+     * Update a task
+     * @returns void
+     * @throws ApiError
+     */
+    public updateTaskV2({
+        requestBody,
+    }: {
+        /**
+         * A task patch object. All properties are optional. Only "status" can be updated for external tasks.
+         */
+        requestBody: (DocumentId & TaskContextId & TaskProperties),
+    }): CancelablePromise<void> {
+        return this.httpRequest.request({
+            method: 'POST',
+            url: '/v2/tasks/update',
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+
+    /**
+     * Delete a task
+     * @returns void
+     * @throws ApiError
+     */
+    public deleteTaskV2({
+        requestBody,
+    }: {
+        requestBody: DocumentId,
+    }): CancelablePromise<void> {
+        return this.httpRequest.request({
+            method: 'POST',
+            url: '/v2/tasks/delete',
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+
+    /**
+     * Close a task
+     * @returns void
+     * @throws ApiError
+     */
+    public closeTaskV2({
+        requestBody,
+    }: {
+        requestBody: (DocumentId & TaskContextId),
+    }): CancelablePromise<void> {
+        return this.httpRequest.request({
+            method: 'POST',
+            url: '/v2/tasks/close',
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+
+    /**
+     * Reopen a task
+     * @returns void
+     * @throws ApiError
+     */
+    public reopenTaskV2({
+        requestBody,
+    }: {
+        requestBody: (TaskContextId & DocumentId),
+    }): CancelablePromise<void> {
+        return this.httpRequest.request({
+            method: 'POST',
+            url: '/v2/tasks/reopen',
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+
+}

--- a/src/generated/services/UserService.ts
+++ b/src/generated/services/UserService.ts
@@ -1,0 +1,48 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { UserProperties } from '../models/UserProperties';
+import type { UserPropertiesImmutable } from '../models/UserPropertiesImmutable';
+
+import type { CancelablePromise } from '../core/CancelablePromise';
+import type { BaseHttpRequest } from '../core/BaseHttpRequest';
+
+export class UserService {
+
+    constructor(public readonly httpRequest: BaseHttpRequest) {}
+
+    /**
+     * Get user profile
+     * @returns any OK
+     * @throws ApiError
+     */
+    public getUserIdentityV1(): CancelablePromise<(UserPropertiesImmutable & UserProperties)> {
+        return this.httpRequest.request({
+            method: 'GET',
+            url: '/identity',
+        });
+    }
+
+    /**
+     * Update user profile
+     * @returns any OK
+     * @throws ApiError
+     */
+    public updateUserProfileV1({
+        requestBody,
+    }: {
+        /**
+         * User fields to be updated
+         */
+        requestBody: UserProperties,
+    }): CancelablePromise<(UserPropertiesImmutable & UserProperties)> {
+        return this.httpRequest.request({
+            method: 'POST',
+            url: '/identity/update',
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+
+}

--- a/src/global.ts
+++ b/src/global.ts
@@ -1,3 +1,5 @@
+import { Morgen } from "./generated/Morgen";
+
 const { MORGEN_API_KEY, MORGEN_ACCESS_TOKEN } = process.env;
 
 /**
@@ -79,6 +81,17 @@ export async function fetchMorgen(
     ..._opts,
   });
   return resp;
+}
+
+export function morgen() {
+  const Authorization = global.API_KEY
+    ? `ApiKey ${global.API_KEY}`
+    : `Bearer ${JSON.parse(global.TOKEN)}`;
+  return new Morgen({
+    HEADERS: { Authorization },
+    // TODO: Change to https://api.morgen.so
+    BASE: "https://20230926t115812-dot-morgen-d34db.oa.r.appspot.com",
+  });
 }
 
 // TODO: Improve this to match remote deployment

--- a/src/global.ts
+++ b/src/global.ts
@@ -90,7 +90,7 @@ export function morgen() {
   return new Morgen({
     HEADERS: { Authorization },
     // TODO: Change to https://api.morgen.so
-    BASE: "https://20230926t115812-dot-morgen-d34db.oa.r.appspot.com",
+    BASE: "https://20231001t155853-dot-morgen-d34db.oa.r.appspot.com",
   });
 }
 

--- a/src/global.ts
+++ b/src/global.ts
@@ -89,8 +89,6 @@ export function morgen() {
     : `Bearer ${JSON.parse(global.TOKEN)}`;
   return new Morgen({
     HEADERS: { Authorization },
-    // TODO: Change to https://api.morgen.so
-    BASE: "https://20231001t155853-dot-morgen-d34db.oa.r.appspot.com",
   });
 }
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,0 +1,47 @@
+import type { ApiRequestOptions } from "./ApiRequestOptions";
+import type { OpenAPIConfig } from "./OpenAPI";
+import { CancelablePromise } from "./CancelablePromise";
+import { fetchJSON, log } from "../../global";
+
+/**
+ * Request method
+ * @param config The OpenAPI configuration object
+ * @param options The request options from the service
+ * @returns Promise<T>
+ * @throws ApiError
+ */
+export function request<T>(
+  config: OpenAPIConfig,
+  options: ApiRequestOptions
+): CancelablePromise<T> {
+  return new CancelablePromise(
+    async (
+      resolve: (successBody: T) => unknown,
+      reject: (e: Error) => void
+    ) => {
+      const { url, ...rest } = options || { headers: {} };
+      let queryString = "";
+
+      Object.keys(options?.query || {}).forEach((k) => {
+        if (!options.query[k]) return;
+        queryString = queryString + "&" + k + "=" + options.query[k];
+      });
+
+      const headers = rest.headers || {};
+      try {
+        const resp = await fetchJSON(config.BASE + url + "?" + queryString, {
+          ...rest,
+          headers: {
+            ...headers,
+            ...config.HEADERS,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(options.body),
+        });
+        resolve(resp.body);
+      } catch (e) {
+        reject(e);
+      }
+    }
+  );
+}

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,7 +1,7 @@
 import type { ApiRequestOptions } from "./ApiRequestOptions";
 import type { OpenAPIConfig } from "./OpenAPI";
 import { CancelablePromise } from "./CancelablePromise";
-import { fetchJSON, log } from "../../global";
+import { fetchJSON } from "../../global";
 
 /**
  * Request method
@@ -35,6 +35,7 @@ export function request<T>(
             ...headers,
             ...config.HEADERS,
             "Content-Type": "application/json",
+            "User-Agent": `Morgen CW SDK (0.0.1)`,
           },
           body: JSON.stringify(options.body),
         });

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,7 +33,7 @@ export type WorkflowTrigger = {
    * state that tracks which events have already been passed in a previous
    * trigger.
    */
-  eventUpdates: { added: []; removed: []; updated: [] };
+  eventUpdates: { added: []; removed: []; modified: [] };
   /**
    * Accounts that have been integrated by the user in-app.
    */

--- a/tests/local.spec.ts
+++ b/tests/local.spec.ts
@@ -20,7 +20,7 @@ const { log, fetch } = sandbox.util;
 
 const BASIC_TRIGGER: WorkflowTrigger = {
   httpParams: {},
-  eventUpdates: { added: [], removed: [], updated: [] },
+  eventUpdates: { added: [], removed: [], modified: [] },
   accounts: { calendar: [] },
   user: { email: "", firstName: "" },
 };

--- a/tests/local.spec.ts
+++ b/tests/local.spec.ts
@@ -13,10 +13,10 @@ const mockFetch = jest.fn(() =>
 );
 global.fetch = mockFetch as unknown as typeof global.fetch;
 
-import cw, { morgen } from "..";
+import cw, { sandbox } from "..";
 import { WorkflowTrigger } from "../dist/types";
 
-const { log, fetch } = morgen.util;
+const { log, fetch } = sandbox.util;
 
 const BASIC_TRIGGER: WorkflowTrigger = {
   httpParams: {},

--- a/tests/remote.spec.ts
+++ b/tests/remote.spec.ts
@@ -25,7 +25,7 @@ describe("Workflow", () => {
         "Testing remote logs",
       ]);
       expect(remoteOutput.result).toBe(123);
-    });
+    }, 20000);
     // TODO:
     //   - create a Morgen user account for E2E tests specifically
     it("lists events", async () => {
@@ -100,6 +100,6 @@ describe("Workflow", () => {
       await wf.upload();
       const remoteOutput = await wf.trigger();
       expect(typeof remoteOutput.result).toBe("number");
-    });
+    }, 20000);
   });
 });

--- a/tests/remote.spec.ts
+++ b/tests/remote.spec.ts
@@ -1,8 +1,8 @@
 import { describe } from "node:test";
 
-import cw, { morgen } from "..";
-const { log, fetchMorgen } = morgen.util;
-const { luxon } = morgen.deps;
+import cw, { sandbox } from "..";
+const { log, morgen } = sandbox.util;
+const { luxon } = sandbox.deps;
 
 // NOTE: These tests require setting MORGEN_API_KEY and the Workflow should be
 // configured to have a calendar account (via the UI because it's the only way)
@@ -38,24 +38,63 @@ describe("Workflow", () => {
           if (!trigger.accounts?.calendar?.[0]?.calendarId)
             throw new Error("No calendar configured!");
           const calId = trigger.accounts.calendar[0].calendarId;
+          const accId = trigger.accounts.calendar[0].accountId;
           const todayStart = luxon.DateTime.now()
             .startOf("day")
             .toISO({ includeOffset: false, suppressMilliseconds: true });
           const todayEnd = luxon.DateTime.now()
             .endOf("day")
             .toISO({ includeOffset: false, suppressMilliseconds: true });
-          const resp = await fetchMorgen(
-            "https://sync.morgen.so/v1/events/list" +
-              `?calendarIds=${calId}` +
-              `&start=${todayStart}` +
-              `&end=${todayEnd}`,
-            {
-              method: "GET",
-            }
+
+          const resp = await morgen().events.listEventsV3({
+            start: todayStart!,
+            end: todayEnd!,
+            accountId: accId,
+            calendarIds: calId,
+          });
+
+          let count = resp.data?.events?.length;
+          log("Events today: " + count);
+
+          const accounts = await morgen().accounts.listAccountsV3();
+          count = accounts.data?.accounts?.length;
+          log("Accounts: " + count);
+
+          const calendars = await morgen().calendars.listCalendarsV3();
+          log(JSON.stringify(calendars.data?.calendars, null, 2));
+          const calendarColors = calendars.data?.calendars
+            ?.map((cal) => ({
+              col: cal.color,
+              name: cal.name,
+              isBusy: cal["morgen.so:metadata"]?.busy,
+            }))
+            .filter((c) => c.isBusy);
+          log(
+            "Busy calendars: " +
+              calendarColors?.length +
+              ": " +
+              JSON.stringify(calendarColors)
           );
-          const eventsCount = resp.body.data.events.length;
-          log("Events today: " + eventsCount);
-          return eventsCount;
+
+          const tasks = await morgen().tasks.listTasksV2({
+            showCompleted: false,
+            updatedAfter: todayStart! + "Z",
+          });
+          count = tasks.length;
+          log("Tasks created today: " + count);
+
+          const { firstName, lastName, email } =
+            await morgen().user.getUserIdentityV1();
+          log(
+            "User: " +
+              JSON.stringify({
+                firstName,
+                lastName,
+                email,
+              })
+          );
+
+          return count;
         }
       );
       await wf.upload();


### PR DESCRIPTION
- Adds a new client API for accessing `morgen-backend` APIs via a TypeScript interface based on an updated OpenAPI spec
- Updates the SDK to use the client
- Updates the SDK to inject the client code into the global scope of the user's script
  - This part is a _little bit_ hacky because it involves replacing generated TypeScript module references with global references. To do this properly would involve writing the build process as part of the workflow upload which is de-scoped for this version.
- Adds several examples to showcase the API client and educate (but there's no real documentation yet)

Most of the diff is generated code 😉 